### PR TITLE
Enable development DB table: tasks_dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # blackrock_backend
 This repo is meant to hold the backend code for the TOC + Blackrock coding project
 
-KD: I could not access the server outside of the container with "flask run" instead, I had to use this command
+KD: I could not access the server outside of the container with "flask run". Instead, I had to use this command:
 flask run --host=0.0.0.0
+
+KD: To use the new development database table (named: tasks_dev), set the DB_TABLE env var BEFORE executing the "flask run" command. The code will default to using the production DB table, unless the environment var is set.
+
+- To set the dev table, execute:
+export DB_TABLE=tasks_dev
+
+- To unset the dev table (revert to prod version), execute:
+unset DB_TABLE

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 from config import Config
 from sqlalchemy import Column, Integer, String, Enum, DateTime
 from datetime import datetime, timedelta
-import enum, json
+import enum, json, os
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -11,7 +11,6 @@ rds = SQLAlchemy(app)
 app.debug = True
 
 from models import Task, StatusEnum
-
 
 
 @app.cli.command('db_create')
@@ -24,22 +23,37 @@ def db_drop():
     rds.drop_all()
     print('Database dropped!')
 
+@app.cli.command('db_showtable')
+def db_showtable():
+    print Task.__tablename__
+
 @app.cli.command('db_seed')
 def db_seed():
+
+    currenttime = datetime.now()
+    endtime = currenttime + timedelta(seconds=600)
+
     tsk1 = Task(
                 name='Cook Eggs',
                 description='Cooking eggs for the family',
                 priority=1,
-                status='ACTIVE'
+                status='ACTIVE',
+                starttime = currenttime,
+                currenttime = currenttime,
+                createdtime = currenttime,
+                endtime = endtime
                 )
 
     tsk2 = Task(
                 name='Boil Water',
                 description='Heating up water on the stove',
                 priority=3,
-                status='PENDING'
+                status='PENDING',
+                starttime = currenttime,
+                currenttime = currenttime,
+                createdtime = currenttime,
+                endtime = endtime
                 )
-
     
     rds.session.add(tsk1)
     rds.session.add(tsk2)

--- a/models.py
+++ b/models.py
@@ -1,7 +1,9 @@
 from app import rds
 from sqlalchemy import Column, Integer, String, Enum, DateTime
 from datetime import datetime
-import enum
+import enum, os
+
+db_table = os.environ.get('DB_TABLE','tasks')
 
 class StatusEnum(enum.Enum):
     PENDING = 1
@@ -9,7 +11,7 @@ class StatusEnum(enum.Enum):
     COMPLETED = 3
 
 class Task(rds.Model):
-    __tablename__ = 'tasks'
+    __tablename__ = db_table
 
     task_id     = Column(Integer, primary_key=True)
     name        = Column(String(64), index=True)


### PR DESCRIPTION
I created a new table on AWS for dev work (tasks_dev). This code allows a developer to set the target table by updating the DB_TABLE environment variable as noted in the README.md.